### PR TITLE
support simple single primative uri parameters

### DIFF
--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -158,7 +158,12 @@ function Client (options) {
   }
 
   function toParamsFunction (child: NestedResource, _client: string, _prefix: string) {
-    return `function (uriParams) { return new ${child.id}(${_client}, ${_prefix}template(${stringify(child.relativeUri)}, extend(${stringify(getDefaultParameters(child.uriParameters))}, uriParams))) }`
+    const keys = Object.keys(child.uriParameters);
+    let uriParams = 'uriParams';
+    if (keys.length === 1) {
+      uriParams = `typeof(uriParams) === 'object' ? uriParams : {'${keys[0]}': uriParams}`
+    }
+    return `function (uriParams) { return new ${child.id}(${_client}, ${_prefix}template(${stringify(child.relativeUri)}, extend(${stringify(getDefaultParameters(child.uriParameters))}, ${uriParams}))) }`
   }
 
   // Create prototype resources.

--- a/test/specs/resource-chain.js
+++ b/test/specs/resource-chain.js
@@ -23,6 +23,13 @@ test('resource chain', function (t) {
           t.equal(res.status, 200)
         })
     })
+    t.test('dynamically generate the resource chain with primative input', function (t) {
+      return client.bounce.parameter.variable(123).get()
+        .then(function (res) {
+          t.equal(res.body, '123')
+          t.equal(res.status, 200)
+        })
+    })
   })
 
   t.test('null uri parameter', function (t) {


### PR DESCRIPTION
Given a resource of `users/{userId}`, the method `users.userId({userId: 123})` is overly verbose and redunant. If the given URI has a single param and the input value passed is a single primative value, then resolve this automatically so that you can simply call `users.userId(123)`.

The later was the way it worked in previous versions of the generated template.