### PR TITLE
fix for incorrect property name

### DIFF
--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -205,9 +205,9 @@ function Client (options) {
       const constructor = `new ${child.id}(${_client}, ${_prefix}${stringify(child.relativeUri)})`
 
       if (withParams[key] == null) {
-        s.line(`  this.${child.methodName} = ${constructor}`)
+        s.line(`  this['${child.methodName}'] = ${constructor}`)
       } else {
-        s.line(`  this.${child.methodName} = setprototypeof(${toParamsFunction(withParams[key], _client, _prefix)}, ${constructor})`)
+        s.line(`  this['${child.methodName}'] = setprototypeof(${toParamsFunction(withParams[key], _client, _prefix)}, ${constructor})`)
       }
     }
   }


### PR DESCRIPTION
Hello, everyone.
Thank you for this module, I'm using it for my node JS project.

Recently I've got an error. My api contains url with zero as one of parts:

> /api/0/someMethodName

And this causes error, because generated client contains code

> this.0

This is correct url, but incorrect JS client code.
So I suggest changing client template to safer property addressing through square brackets.  