### PR TITLE
Requests logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-javascript-generator",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Generate a JavaScript API client from RAML",
   "main": "dist/index.js",
   "config": {

--- a/src/templates/README.md.ts
+++ b/src/templates/README.md.ts
@@ -31,6 +31,10 @@ var ${className} = require('${projectName}')
 
 var client = new ${className}()
 \`\`\`
+
+### Logging
+
+This client supports logging by using the environment variable \`NODE_DEBUG=${api.title}\`
 `);
 
   if (hasSecurity(api, 'OAuth 2.0')) {

--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -65,7 +65,7 @@ class ClientTemplateGenerator {
 
     this.buffer.multiline(`const rp = require('request-promise');
 const queryString = require('query-string');
-const fs = require('fs');
+const debuglog = require('util').debuglog('raml-javascript-generator');
 
 const TEMPLATE_REGEXP = /\{\\+?([^\{\}]+)\}/g;
 
@@ -77,12 +77,6 @@ const template = (string, interpolate) =>
 
     return '';
   });
-
-const failSafePromisifiedAppendFile = (path, data, options) =>
-  new Promise((resolve) =>
-    fs.appendFile(path, data, options, () => {
-      resolve();
-    }));
 
 const request = (client, method, path, opts) => {
   const headers = opts.headers ?
@@ -110,18 +104,13 @@ const request = (client, method, path, opts) => {
     reqOpts = options.user.sign(reqOpts);
   }
 
-  let logRequestPromise = Promise.resolve();
-  if (options.logRequestsPath) {
-    logRequestPromise = failSafePromisifiedAppendFile(options.logRequestsPath, JSON.stringify(reqOpts, null, 2), 'utf8');
-  }
+  debuglog(reqOpts);
 
-  return logRequestPromise
-    .then(() => rp(reqOpts))
-    .then((response) => {
-      // adding backward compatibility
-      response.status = response.statusCode;
-      return response;
-    });
+  return rp(reqOpts).then((response) => {
+    // adding backward compatibility
+    response.status = response.statusCode;
+    return response;
+  });
 };`);
   }
 

--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -65,7 +65,7 @@ class ClientTemplateGenerator {
 
     this.buffer.multiline(`const rp = require('request-promise');
 const queryString = require('query-string');
-const debuglog = require('util').debuglog('raml-javascript-generator');
+const debuglog = require('util').debuglog('${this.api.title}');
 
 const TEMPLATE_REGEXP = /\{\\+?([^\{\}]+)\}/g;
 
@@ -107,6 +107,12 @@ const request = (client, method, path, opts) => {
   debuglog(reqOpts);
 
   return rp(reqOpts).then((response) => {
+    debuglog({
+      headers: response.headers,
+      body: response.body,
+      statusCode: response.statusCode
+    });
+
     // adding backward compatibility
     response.status = response.statusCode;
     return response;


### PR DESCRIPTION
This PR adds debug logging to requests performed by generated clients.

Usage instructions are added to the README. The idea is that by using the [`util.debuglog`](https://nodejs.org/api/util.html#util_util_debuglog_section) functionality, the user of a generated client can log request information by using `NODE_DEBUG=api-title`.