### PR TITLE
Add logging for failed requests response

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ var jsGenerator = require('raml-javascript-generator')
 var output = jsGenerator(/* api, data */)
 ```
 
+## Generated Client Logging
+
+Generated clients support logging of requests performed. To activate the logging set the `NODE_DEBUG` environment variable to the name of the generated client.
+
+The data for the request performed and the response received will be displayed in the output.
+
 ## License
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-javascript-generator",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Generate a JavaScript API client from RAML",
   "main": "dist/index.js",
   "config": {

--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -104,19 +104,27 @@ const request = (client, method, path, opts) => {
     reqOpts = options.user.sign(reqOpts);
   }
 
-  debuglog(reqOpts);
+  debuglog(\`[REQUEST]: \${JSON.stringify(reqOpts, null, 2)}\`);
 
-  return rp(reqOpts).then((response) => {
-    debuglog({
-      headers: response.headers,
-      body: response.body,
-      statusCode: response.statusCode
+  return rp(reqOpts)
+    .then((response) => {
+      const responseLog = {
+        headers: response.headers,
+        body: response.body,
+        statusCode: response.statusCode
+      };
+      debuglog(\`[RESPONSE]: \${JSON.stringify(responseLog, null, 2)}\`);
+
+      // adding backward compatibility
+      response.status = response.statusCode;
+      return response;
+    })
+    .catch((error) => {
+      debuglog(\`[RESPONSE]: \${JSON.stringify(error, null, 2)}\`);
+
+      // rethrow the error so that the returned promise is rejected
+      throw error;
     });
-
-    // adding backward compatibility
-    response.status = response.statusCode;
-    return response;
-  });
 };`);
   }
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds the logging of failed requests responses. When the request fails the promise is rejected, so this wasn't being logged. After logging the response of a failed request, the error is rethrown so that this logging is transparent for the end user, the promise will still be rejected.
- Adds a tag `[REQUEST]` or `[RESPONSE]` to the logs so they are easier to identify.
- Adds a small section to the README briefly explaining how to activate the logging for a generated client.