### PR TITLE
fix(client): pass correct client reference to root resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-dist: xenial
-
-services:
-  - xvfb
+dist: trusty
 
 language: node_js
 
@@ -10,6 +7,7 @@ sudo: required
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-language: node_js
-
-sudo: required
+dist: xenial
 
 services:
   - xvfb
+
+language: node_js
+
+sudo: required
 
 before_install:
   - export CHROME_BIN=chromium-browser

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 
 sudo: required
 
+services:
+  - xvfb
+
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 cache:
   directories:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-javascript-generator",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-javascript-generator",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Generate a JavaScript API client from RAML",
   "main": "dist/index.js",
   "config": {

--- a/src/support/method.ts
+++ b/src/support/method.ts
@@ -25,8 +25,7 @@ export function getRequestSnippet(method: any, resource: any) {
   }
 
   const parts = resource.relativeUri.split(/(?=[\/\.])/g);
-
-  return parts.map((part: string) => {
+  const requestMethod = parts.map((part: string) => {
     const methodName = toMethodName(part);
     const uriParams = Object.keys(getUsedUriParameters(part, resource.uriParameters));
 
@@ -35,7 +34,9 @@ export function getRequestSnippet(method: any, resource: any) {
     }
 
     return `${methodName}`;
-  }).join('.') + `.${camelCase(method.method)}([${type}, [options]])`;
+  }).join('.');
+
+  return `${requestMethod}.${camelCase(method.method)}([${type}, [options]])`;
 }
 
 /**

--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -186,7 +186,7 @@ const request = (client, method, path, opts) => {
   }
 
   // Create prototype resources.
-  private createProtoResources(withParams: KeyedNestedResources, noParams: KeyedNestedResources) {
+  private createProtoResources(withParams: KeyedNestedResources, client: string, noParams: KeyedNestedResources) {
     for (const key of Object.keys(withParams)) {
       const child = withParams[key];
 
@@ -196,7 +196,7 @@ const request = (client, method, path, opts) => {
       }
 
       this.buffer.append(`\n`);
-      this.buffer.append(`  ${child.methodName}${this.toParamsMethod(child, 'this', true)}`);
+      this.buffer.append(`  ${child.methodName}${this.toParamsMethod(child, client, true)}`);
     }
   }
 
@@ -223,7 +223,7 @@ const request = (client, method, path, opts) => {
 
       this.createThisResources(withParams, noParams, 'this.client');
       this.buffer.line(`  }`);
-      this.createProtoResources(withParams, noParams);
+      this.createProtoResources(withParams, 'this.client', noParams);
       this.createProtoMethods(resource.methods, 'this.client', 'this.path');
       if (className.indexOf('.') > 0) {
         this.buffer.line(`};`);
@@ -368,7 +368,7 @@ class Client {
       }
     }
     this.createProtoMethods(this.nestedTree.methods, 'this', `''`);
-    this.createProtoResources(this.withParams, this.noParams);
+    this.createProtoResources(this.withParams, 'this', this.noParams);
     this.buffer.line(`}`);
   }
 

--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -196,7 +196,7 @@ const request = (client, method, path, opts) => {
       }
 
       this.buffer.append(`\n`);
-      this.buffer.append(`  ${child.methodName}${this.toParamsMethod(child, 'this.client', true)}`);
+      this.buffer.append(`  ${child.methodName}${this.toParamsMethod(child, 'this', true)}`);
     }
   }
 

--- a/src/templates/index.js.ts
+++ b/src/templates/index.js.ts
@@ -382,7 +382,7 @@ class Client {
 
       if (scheme.type === 'OAuth 2.0') {
         this.buffer.return();
-        this.buffer.line('// eslint-disable-next-line');
+        this.buffer.line('  // eslint-disable-next-line');
         this.buffer.line(`  ${name}: function ${name}(options) {`);
         this.buffer.multiline(`    const schemeSettings = ${this.formatJSON(scheme.settings, 2, 4)};`);
         this.buffer.line(`    return new ClientOAuth2(Object.assign(schemeSettings, options));`);

--- a/src/templates/package.json.ts
+++ b/src/templates/package.json.ts
@@ -35,5 +35,5 @@ export const packageTemplate = (api: Api) => {
     }
   };
 
-  return JSON.stringify(json, null, 2) + '\n';
+  return `${JSON.stringify(json, null, 2)}\n`;
 };


### PR DESCRIPTION
There is a minor issue that's causing an error executing root resources defined with path params.

Considering this path `/{user}`, the resulted client is:

```js
class Client {
  ...
  
  user(uriParams) {
    return new User(
      this.client,
      this.path + template('/{user}',
        Object.assign({}, uriParams))
    );
  }
}
```

Despite `user` method is defined within `Client` class, the `User` class is instantiated with `this.client`. Such property isn't defined inside `Client` and in fact, based on the logic, it expects a instance of `Client` so just providing `this` fixes the issue.

After applying the fix, that portion of code looks like this:

```js
class Client {
  ...
  
  user(uriParams) {
    return new User(
      this,
      this.path + template('/{user}',
        Object.assign({}, uriParams))
    );
  }
}
```
